### PR TITLE
Add preserve_null flag

### DIFF
--- a/pre_commit_hooks/yamlfmt
+++ b/pre_commit_hooks/yamlfmt
@@ -132,7 +132,7 @@ class Formatter:
         yaml.preserve_quotes = kwargs.get("preserve_quotes", False)
 
         if kwargs.get("preserve_null"):
-            def represent_none(self, data):
+            def represent_none(self, _data):
                 return self.represent_scalar('tag:yaml.org,2002:null', 'null')
             yaml.representer.add_representer(type(None), represent_none)
 

--- a/pre_commit_hooks/yamlfmt
+++ b/pre_commit_hooks/yamlfmt
@@ -132,9 +132,9 @@ class Formatter:
         yaml.preserve_quotes = kwargs.get("preserve_quotes", False)
 
         if kwargs.get("preserve_null"):
-          def represent_none(self, data):
-              return self.represent_scalar(u'tag:yaml.org,2002:null', u'null')
-          yaml.representer.add_representer(type(None), represent_none)
+            def represent_none(self, data):
+                return self.represent_scalar(u'tag:yaml.org,2002:null', u'null')
+            yaml.representer.add_representer(type(None), represent_none)
 
         self.yaml = yaml
         self.path = kwargs.get("path", None)

--- a/pre_commit_hooks/yamlfmt
+++ b/pre_commit_hooks/yamlfmt
@@ -185,7 +185,6 @@ if __name__ == "__main__":
         width=ARGS.width,
         preserve_quotes=ARGS.preserve_quotes,
         preserve_null=ARGS.preserve_null,
-        implicit_start=ARGS.implicit_start,
         explicit_start=ARGS.explicit_start,
         explicit_end=ARGS.explicit_end
         )

--- a/pre_commit_hooks/yamlfmt
+++ b/pre_commit_hooks/yamlfmt
@@ -132,7 +132,7 @@ class Formatter:
         yaml.preserve_quotes = kwargs.get("preserve_quotes", False)
 
         if kwargs.get("preserve_null"):
-            def represent_none(self):
+            def represent_none(self, data):
                 return self.represent_scalar('tag:yaml.org,2002:null', 'null')
             yaml.representer.add_representer(type(None), represent_none)
 

--- a/pre_commit_hooks/yamlfmt
+++ b/pre_commit_hooks/yamlfmt
@@ -132,8 +132,8 @@ class Formatter:
         yaml.preserve_quotes = kwargs.get("preserve_quotes", False)
 
         if kwargs.get("preserve_null"):
-            def represent_none(self, data):
-                return self.represent_scalar(u'tag:yaml.org,2002:null', u'null')
+            def represent_none(self):
+                return self.represent_scalar('tag:yaml.org,2002:null', 'null')
             yaml.representer.add_representer(type(None), represent_none)
 
         self.yaml = yaml

--- a/pre_commit_hooks/yamlfmt
+++ b/pre_commit_hooks/yamlfmt
@@ -184,7 +184,7 @@ if __name__ == "__main__":
         colons=ARGS.colons,
         width=ARGS.width,
         preserve_quotes=ARGS.preserve_quotes,
-        preserve_null=ARGS.preserve_null
+        preserve_null=ARGS.preserve_null,
         implicit_start=ARGS.implicit_start,
         explicit_start=ARGS.explicit_start,
         explicit_end=ARGS.explicit_end

--- a/pre_commit_hooks/yamlfmt
+++ b/pre_commit_hooks/yamlfmt
@@ -175,6 +175,7 @@ class Formatter:
         sys.stderr.write(msg)
         sys.exit(1)
 
+
 if __name__ == "__main__":
     ARGS = Cli().parser.parse_args()
     FORMATTER = Formatter(

--- a/pre_commit_hooks/yamlfmt
+++ b/pre_commit_hooks/yamlfmt
@@ -70,6 +70,12 @@ class Cli:
             help="whether to remove the explicit document start"
             )
         parser.add_argument(
+            "-n",
+            "--preserve_null",
+            action="store_true",
+            help="whether to keep null values"
+            )
+        parser.add_argument(
             "file_names",
             metavar="FILE_NAME",
             nargs="*",
@@ -94,6 +100,11 @@ class Formatter:
         yaml.explicit_start = kwargs.get("implicit_start", True)
         yaml.width = kwargs.get("width", None)
         yaml.preserve_quotes = kwargs.get("preserve_quotes", False)
+
+        if kwargs.get("preserve_null"):
+          def represent_none(self, data):
+              return self.represent_scalar(u'tag:yaml.org,2002:null', u'null')
+          yaml.representer.add_representer(type(None), represent_none)
 
         self.yaml = yaml
         self.path = kwargs.get("path", None)
@@ -134,7 +145,6 @@ class Formatter:
         sys.stderr.write(msg)
         sys.exit(1)
 
-
 if __name__ == "__main__":
     ARGS = Cli().parser.parse_args()
     FORMATTER = Formatter(
@@ -144,7 +154,8 @@ if __name__ == "__main__":
         colons=ARGS.colons,
         width=ARGS.width,
         preserve_quotes=ARGS.preserve_quotes,
-        implicit_start=ARGS.implicit_start
+        implicit_start=ARGS.implicit_start,
+        preserve_null=ARGS.preserve_null
         )
     for file_name in ARGS.file_names:
         FORMATTER.format(file_name)


### PR DESCRIPTION
Added a new `preserve_null` flag which preserves null values:
```
foo: null
```

As described here:
https://stackoverflow.com/questions/57172997/yaml-dumper-outputs-blank-instead-of-null-from-none-value-how-to-make-it-output