### PR TITLE
fix: setuptools breaks pre-commit run due to auto-discovery changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,8 @@ setup(
     scripts=[
         'pre_commit_hooks/yamlfmt',
     ],
+
+    # explicitly declare packages so setuptools does not attempt auto discovery
+    # taken from https://github.com/pypa/setuptools/issues/3197
+    packages=[],
 )


### PR DESCRIPTION
Seems like `virtualenv` [v20.14.0](https://github.com/pypa/virtualenv/blob/main/docs/changelog.rst#v20140-2022-03-25) (released just yesterday) upgraded setuptools to `v61.1.0` ([changelog](https://setuptools.pypa.io/en/latest/history.html#v61-1-0)) that includes few `auto-discovery` changes that break [pre-commit-hook-yamlfmt](https://github.com/jumanjihouse/pre-commit-hook-yamlfmt) hook `setup.py`.

There's an [issue](https://github.com/pypa/setuptools/issues/3197) in setuptools which includes [this workaround](https://github.com/inmanta/inmanta/commit/654006181663db4ac40c8f82dea58b80bd4b588c).