### PR TITLE
Consolidate prs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ fail_fast: false
 
 repos:
     - repo: https://github.com/adrienverge/yamllint.git
-      rev: v1.21.0
+      rev: v1.26.3
       hooks:
           - id: yamllint
             args: [--format, parsable, --strict]
@@ -36,7 +36,7 @@ repos:
             args: [--mapping, '2', --sequence, '2', --offset, '0']
 
     - repo: https://github.com/jumanjihouse/pre-commit-hooks
-      rev: 2.0.0
+      rev: 2.1.6
       hooks:
           - id: check-mailmap
           - id: forbid-binary
@@ -52,27 +52,27 @@ repos:
             args: [-d, -i 4, -ci]
 
     - repo: https://github.com/PyCQA/bandit
-      rev: 1.6.2
+      rev: 1.7.4
       hooks:
           - id: bandit
 
     - repo: https://github.com/PyCQA/flake8
-      rev: 3.7.9
+      rev: 4.0.1
       hooks:
           - id: flake8
 
     - repo: https://github.com/PyCQA/pydocstyle
-      rev: 5.0.2
+      rev: 6.1.1
       hooks:
           - id: pydocstyle
 
     - repo: https://github.com/PyCQA/pylint
-      rev: pylint-2.4.2
+      rev: v2.13.8
       hooks:
           - id: pylint
 
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.5.0
+      rev: v4.2.0
       hooks:
           - id: check-added-large-files
           - id: check-byte-order-marker
@@ -91,7 +91,7 @@ repos:
           - id: sort-simple-yaml
 
     - repo: https://github.com/Lucas-C/pre-commit-hooks
-      rev: v1.1.7
+      rev: v1.1.13
       hooks:
           - id: forbid-crlf
           - id: forbid-tabs
@@ -111,7 +111,7 @@ repos:
             stages: [manual]
 
     - repo: https://github.com/Yelp/detect-secrets
-      rev: v0.13.1
+      rev: v1.2.0
       hooks:
           - id: detect-secrets
             args: [--baseline, ci/secrets.baseline]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ I recommend to use `yamllint` and `yamlfmt` together.
             args: [--format, parsable, --strict]
 
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-      rev: 0.0.11  # or specific tag
+      rev: 0.1.1  # or specific tag
       hooks:
           - id: yamlfmt
 
@@ -85,7 +85,7 @@ I recommend to use `yamllint` and `yamlfmt` together.
 Add to `.pre-commit-config.yaml` in your git repo:
 
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-      rev: 0.0.11  # or specific tag
+      rev: 0.1.1  # or specific tag
       hooks:
           - id: yamlfmt
             args: [--mapping, '2', --sequence, '2', --offset, '0', --colons, --width, '150']

--- a/pre_commit_hooks/yamlfmt
+++ b/pre_commit_hooks/yamlfmt
@@ -63,18 +63,47 @@ class Cli:
             action="store_true",
             help="whether to keep existing string quoting"
             )
-        parser.add_argument(
-            "-e",
+
+        document_start = parser.add_mutually_exclusive_group()
+        document_start.add_argument(
             "--implicit_start",
+            "-e",
             action="store_false",
+            dest="explicit_start",
+            default=argparse.SUPPRESS,
             help="whether to remove the explicit document start"
             )
+        document_start.add_argument(
+            "--explicit_start",
+            action="store_true",
+            dest="explicit_start",
+            default=True,
+            help="whether to add the explicit document start"
+            )
+
+        document_end = parser.add_mutually_exclusive_group()
+        document_end.add_argument(
+            "--implicit_end",
+            action="store_false",
+            dest="explicit_end",
+            default=argparse.SUPPRESS,
+            help="whether to remove the explicit document end"
+            )
+        document_end.add_argument(
+            "--explicit_end",
+            action="store_true",
+            dest="explicit_end",
+            default=False,
+            help="whether to add the explicit document end"
+            )
+
         parser.add_argument(
             "file_names",
             metavar="FILE_NAME",
             nargs="*",
             help="space-separated list of YAML file names",
             )
+
         self.parser = parser
 
 
@@ -91,7 +120,8 @@ class Formatter:
             offset=kwargs.get("offset", DEFAULT_INDENT["offset"]),
             )
         yaml.top_level_colon_align = kwargs.get("colons", False)
-        yaml.explicit_start = kwargs.get("implicit_start", True)
+        yaml.explicit_start = kwargs.get("explicit_start", True)
+        yaml.explicit_end = kwargs.get("explicit_end", False)
         yaml.width = kwargs.get("width", None)
         yaml.preserve_quotes = kwargs.get("preserve_quotes", False)
 
@@ -144,7 +174,8 @@ if __name__ == "__main__":
         colons=ARGS.colons,
         width=ARGS.width,
         preserve_quotes=ARGS.preserve_quotes,
-        implicit_start=ARGS.implicit_start
+        explicit_start=ARGS.explicit_start,
+        explicit_end=ARGS.explicit_end
         )
     for file_name in ARGS.file_names:
         FORMATTER.format(file_name)

--- a/pre_commit_hooks/yamlfmt
+++ b/pre_commit_hooks/yamlfmt
@@ -113,7 +113,7 @@ class Formatter:
         if not path:
             path = self.path
         try:
-            with open(path, "r") as stream:
+            with open(path, "r", encoding='utf-8') as stream:
                 self.content = list(self.yaml.load_all(stream))
         except IOError:
             self.fail(f"Unable to read {path}")
@@ -123,7 +123,7 @@ class Formatter:
         if not path:
             path = self.path
         try:
-            with open(path, "w") as stream:
+            with open(path, "w", encoding='utf-8') as stream:
                 self.yaml.dump_all(self.content, stream)
         except IOError:
             self.fail(f"Unable to write {path}")


### PR DESCRIPTION
This PR has several commits to:

- bump pre-commit hook versions
- resolve pylint suggestion to use explicit encoding (as opposed to default)
- add support for `explicit_end` using the commit from https://github.com/jumanjihouse/pre-commit-hook-yamlfmt/pull/21 (thanks @archoversight)
- update example in readme from https://github.com/jumanjihouse/pre-commit-hook-yamlfmt/pull/35 (thanks @rsnodgrass)