### PR TITLE
Adds ability to set explicit null value

### DIFF
--- a/ci/nulls-after.txt
+++ b/ci/nulls-after.txt
@@ -1,0 +1,11 @@
+---
+# Nulls in YAML - https://yaml.org/type/null.html
+nulls_in_list:
+    - null
+    - null
+    - null
+    - null
+explicit_lower_null: null
+explicit_upper_null: null
+explicit_tilde: null
+empty_is_null: null

--- a/ci/nulls-before.txt
+++ b/ci/nulls-before.txt
@@ -1,0 +1,11 @@
+---
+# Nulls in YAML - https://yaml.org/type/null.html
+nulls_in_list:
+    - null
+    - NULL
+    - ~
+    -
+explicit_lower_null: null
+explicit_upper_null: NULL
+explicit_tilde: ~
+empty_is_null:

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,3 +1,3 @@
 md-toc==6.0.2
 pre-commit==2.2.0
-ruamel.yaml==0.16.10
+ruamel.yaml==0.16.13

--- a/ci/test
+++ b/ci/test
@@ -40,6 +40,14 @@ run diff ci/quotes-after.txt "${TMP_FILE}"
 # If the diff fails, the temp file is still there to inspect.
 run rm -f "${TMP_FILE}"
 
+# Test preserve quotes
+TMP_FILE="$(mktemp pre-commit-hook-yamlfmt-test.XXXXXXXXXXXXXXXXXXXX)"
+run cp -f ci/nulls-before.txt "${TMP_FILE}"
+run pre_commit_hooks/yamlfmt --mapping 4 --sequence 6 --offset 4 --null-value null "${TMP_FILE}"
+run diff ci/nulls-after.txt "${TMP_FILE}"
+# If the diff fails, the temp file is still there to inspect.
+run rm -f "${TMP_FILE}"
+
 # Test width setting
 TMP_FILE="$(mktemp pre-commit-hook-yamlfmt-test.XXXXXXXXXXXXXXXXXXXX)"
 run cp -f ci/test-long.txt "${TMP_FILE}"

--- a/pre_commit_hooks/yamlfmt
+++ b/pre_commit_hooks/yamlfmt
@@ -63,6 +63,13 @@ class Cli:
             action="store_true",
             help="whether to keep existing string quoting"
             )
+        parser.add_argument(
+            "-n",
+            "--null-value",
+            type=str,
+            default="",
+            help="what to put in place of nulls"
+        )
 
         document_start = parser.add_mutually_exclusive_group()
         document_start.add_argument(
@@ -124,6 +131,12 @@ class Formatter:
         yaml.explicit_end = kwargs.get("explicit_end", False)
         yaml.width = kwargs.get("width", None)
         yaml.preserve_quotes = kwargs.get("preserve_quotes", False)
+        yaml.representer.add_representer(
+            type(None),
+            lambda representer, _: representer.represent_scalar(
+                "tag:yaml.org,2002:null", kwargs.get("null_value", "")
+            )
+        )
 
         self.yaml = yaml
         self.path = kwargs.get("path", None)
@@ -174,6 +187,7 @@ if __name__ == "__main__":
         colons=ARGS.colons,
         width=ARGS.width,
         preserve_quotes=ARGS.preserve_quotes,
+        null_value=ARGS.null_value,
         explicit_start=ARGS.explicit_start,
         explicit_end=ARGS.explicit_end
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version='0.0.0',
 
     install_requires=[
-        'ruamel.yaml>=0.16.10',
+        'ruamel.yaml>=0.16.13',
     ],
 
     scripts=[


### PR DESCRIPTION
Hi there,
The YAML spec allows for multiple ways to specify when a value is "null" - https://yaml.org/type/null.html

In your current implementation, it always defaults to an empty string, which I think is a sensible default. However, one of our downstream systems is unfortunately failing to handle empty strings.

This PR adds a new CLI argument `--null-value`, where you could specify how null values should be represented (typically `~`, `null`, `NULL`).

Implementation was inspired by:
- https://stackoverflow.com/a/65692753/31506
- https://github.com/jumanjihouse/pre-commit-hook-yamlfmt/commit/a80e5f11469f8463c528fca26ea1b821746ac56f

I've added a single test to ensure all null representations are handled.

I also have a separate test (not part of this PR) that ensures that the default behavior hasn't changed, if the `--null-value` flag is left off. Unfortunately, the test data (specifically the `after` file) would have trailing spaces, which currently gets rejected by existing tests, and I don't really know how to add an exception to for these. Here's the commit for this one extra test - https://github.com/jackgene/pre-commit-hook-yamlfmt/commit/e2dae703e40b97441ce16fe921c70e5ff3b0357a