### PR TITLE
Silence the pre-commit hook

### DIFF
--- a/pre_commit_hooks/yamlfmt
+++ b/pre_commit_hooks/yamlfmt
@@ -144,10 +144,8 @@ class Formatter:
         """ Read file and write it out to same path """
         if not path:
             path = self.path
-        print(path, end="")
         FORMATTER.parse_file(path)  # pylint: disable=E0601
         FORMATTER.write_file(path)
-        print("  Done")
 
     def parse_file(self, path=None):
         """ Read the file """


### PR DESCRIPTION
This can produce a lot of output which is usually not helpful;
the diff from `--show-diff-on-failure` shows what changed
and the `identity` hook can debug filename selection.