### PR TITLE
Add line-endings argument to enforce specific newline format (fix Windows compatibility issues)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
             args: [-d, -i 4, -ci]
 
     - repo: https://github.com/PyCQA/bandit
-      rev: 1.7.5
+      rev: 1.8.6
       hooks:
           - id: bandit
 

--- a/ci/test
+++ b/ci/test
@@ -51,4 +51,30 @@ run pre_commit_hooks/yamlfmt.py --width 79 "${TMP_FILE}"
 run grep -v -q '.\{82\}' "${TMP_FILE}"
 run rm -f "${TMP_FILE}"
 
+# Test line endings
+# File command will say nothing about line terminators for LF, but will for CRLF and CR endings
+TMP_FILE="$(mktemp pre-commit-hook-yamlfmt-test.XXXXXXXXXXXXXXXXXXXX)"
+run cp -f ci/test-eolchars.txt "${TMP_FILE}"
+run pre_commit_hooks/yamlfmt --mapping 4 --sequence 6 --offset 4 --preserve-quotes "${TMP_FILE}"
+run grep -q -v "CRLF line terminators" <(file -b "${TMP_FILE}")
+run grep -q -v "CR line terminators" <(file -b "${TMP_FILE}")
+# No line-endings argument passed - should be LF only when run on *nix plaftorms
+run cp -f ci/test-eolchars.txt "${TMP_FILE}"
+run pre_commit_hooks/yamlfmt --mapping 4 --sequence 6 --offset 4 --preserve-quotes --line-endings lf "${TMP_FILE}"
+run grep -q -v 'CRLF line terminators' <(file -b "${TMP_FILE}")
+run grep -q -v 'CR line terminators' <(file -b "${TMP_FILE}")
+# LF line-endings argument passed - Should be not CR and not CRLF
+run cp -f ci/test-eolchars.txt "${TMP_FILE}"
+run pre_commit_hooks/yamlfmt --mapping 4 --sequence 6 --offset 4 --preserve-quotes --line-endings crlf "${TMP_FILE}"
+run grep -q 'CRLF line terminators' <(file -b "${TMP_FILE}")
+run grep -q -v 'CR line terminators' <(file -b "${TMP_FILE}")
+# CRLF argument passed - Should be CRLF line terminators
+run cp -f ci/test-eolchars.txt "${TMP_FILE}"
+run pre_commit_hooks/yamlfmt --mapping 4 --sequence 6 --offset 4 --preserve-quotes --line-endings cr "${TMP_FILE}"
+run grep -q -v 'CRLF line terminators' <(file -b "${TMP_FILE}")
+run grep -q 'CR line terminators' <(file -b "${TMP_FILE}")
+# CR argument passed - Should be CR line terminators
+# If the tests fail, the temp file is still there to inspect.
+run rm -f "${TMP_FILE}"
+
 run pre-commit run --all-files --hook-stage manual

--- a/ci/test
+++ b/ci/test
@@ -55,22 +55,22 @@ run rm -f "${TMP_FILE}"
 # File command will say nothing about line terminators for LF, but will for CRLF and CR endings
 TMP_FILE="$(mktemp pre-commit-hook-yamlfmt-test.XXXXXXXXXXXXXXXXXXXX)"
 run cp -f ci/test-eolchars.txt "${TMP_FILE}"
-run pre_commit_hooks/yamlfmt --mapping 4 --sequence 6 --offset 4 --preserve-quotes "${TMP_FILE}"
+run pre_commit_hooks/yamlfmt.py --mapping 4 --sequence 6 --offset 4 --preserve-quotes "${TMP_FILE}"
 run grep -q -v "CRLF line terminators" <(file -b "${TMP_FILE}")
 run grep -q -v "CR line terminators" <(file -b "${TMP_FILE}")
 # No line-endings argument passed - should be LF only when run on *nix plaftorms
 run cp -f ci/test-eolchars.txt "${TMP_FILE}"
-run pre_commit_hooks/yamlfmt --mapping 4 --sequence 6 --offset 4 --preserve-quotes --line-endings lf "${TMP_FILE}"
+run pre_commit_hooks/yamlfmt.py --mapping 4 --sequence 6 --offset 4 --preserve-quotes --line-endings lf "${TMP_FILE}"
 run grep -q -v 'CRLF line terminators' <(file -b "${TMP_FILE}")
 run grep -q -v 'CR line terminators' <(file -b "${TMP_FILE}")
 # LF line-endings argument passed - Should be not CR and not CRLF
 run cp -f ci/test-eolchars.txt "${TMP_FILE}"
-run pre_commit_hooks/yamlfmt --mapping 4 --sequence 6 --offset 4 --preserve-quotes --line-endings crlf "${TMP_FILE}"
+run pre_commit_hooks/yamlfmt.py --mapping 4 --sequence 6 --offset 4 --preserve-quotes --line-endings crlf "${TMP_FILE}"
 run grep -q 'CRLF line terminators' <(file -b "${TMP_FILE}")
 run grep -q -v 'CR line terminators' <(file -b "${TMP_FILE}")
 # CRLF argument passed - Should be CRLF line terminators
 run cp -f ci/test-eolchars.txt "${TMP_FILE}"
-run pre_commit_hooks/yamlfmt --mapping 4 --sequence 6 --offset 4 --preserve-quotes --line-endings cr "${TMP_FILE}"
+run pre_commit_hooks/yamlfmt.py --mapping 4 --sequence 6 --offset 4 --preserve-quotes --line-endings cr "${TMP_FILE}"
 run grep -q -v 'CRLF line terminators' <(file -b "${TMP_FILE}")
 run grep -q 'CR line terminators' <(file -b "${TMP_FILE}")
 # CR argument passed - Should be CR line terminators

--- a/ci/test-eolchars.txt
+++ b/ci/test-eolchars.txt
@@ -1,0 +1,5 @@
+---
+bar:
+    baz:
+        - blah
+        - phfft

--- a/pre_commit_hooks/yamlfmt.py
+++ b/pre_commit_hooks/yamlfmt.py
@@ -104,6 +104,13 @@ class Cli:
             help="whether to keep null values"
             )
         parser.add_argument(
+            "--line-endings",
+            choices=['lf', 'crlf', 'cr'],
+            default="lf",
+            help="write output files with specific EOL (default EOL depends"
+                 " on OS)"
+            )
+        parser.add_argument(
             "file_names",
             metavar="FILE_NAME",
             nargs="*",
@@ -139,6 +146,14 @@ class Formatter:
                 return self.represent_scalar('tag:yaml.org,2002:null', 'null')
             yaml.representer.add_representer(type(None), represent_none)
 
+        line_endings_map = {
+            "lf": "\n",
+            "crlf": "\r\n",
+            "cr": "\r"
+        }
+        self.line_endings = line_endings_map.get(
+            kwargs.get("line_endings", None), None)
+
         self.yaml = yaml
         self.path = kwargs.get("path", None)
         self.content = list({})
@@ -167,7 +182,8 @@ class Formatter:
         if not path:
             path = self.path
         try:
-            with open(path, "w", encoding='utf-8') as stream:
+            with open(path, "w", encoding='utf-8',
+                      newline=self.line_endings) as stream:
                 self.yaml.dump_all(self.content, stream)
         except IOError:
             self.fail(f"Unable to write {path}")
@@ -191,7 +207,8 @@ def main():
         preserve_quotes=args.preserve_quotes,
         preserve_null=args.preserve_null,
         explicit_start=args.explicit_start,
-        explicit_end=args.explicit_end
+        explicit_end=args.explicit_end,
+        line_endings=args.line_endings
         )
     for file_name in args.file_names:
         formatter.format(file_name)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name='yamlfmt',
     description='A pre-commit hook to format YAML files',
     url='https://github.com/jumanjihouse/pre-commit-hook-yamlfmt',
-    version='0.3.0',
+    version='0.4.0',
 
     install_requires=[
         'ruamel.yaml >=0.16.10, <=0.17.21',


### PR DESCRIPTION
There is an issue on Windows when using this formatter when combined with a linter that is configured to accept only `\n` newlines.  When `pre-commit-hook-yamlfmt` runs, the newlines used for file writes depends on the OS.

Python uses `os.linesep` by default which means on Windows this is `\r\n` and on POSIX it is `\n`
https://docs.python.org/3/library/functions.html#open-newline-parameter


With linter validation running after this formatter, you get stuck in a loop.
1. You fix line endings to `\n` in the YAML files and commit
2. Pre-commit hook runs
3. `yamlfmt` rewrites file with `\r\n` line endings
4. `yamllint` fails since it wants `\n` line endings (with `new-lines: enabled`)

Example scenario of this happening: https://github.com/netbox-community/devicetype-library/discussions/1361#discussion-5203255


This PR adds an optional `--line-endings` argument which allows overriding this default python behavior.  This allows projects to explicitly specify the line ending format they need for their use case and support multiple development platforms.

This is implemented by simply using the `newline` parameter on the `open()` call for file writes.


Tests have been added to cover:
- No `--line-endings` provided (i.e. all current use of this formatter)
- Calling with `--line-endings lf`
- Calling with `--line-endings crlf`
- Calling with `--line-endings cr`