### PR TITLE
Windows fix shebang path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - id: yamlfmt
             name: Format YAML files
             description: Format YAML files
-            entry: pre_commit_hooks/yamlfmt
+            entry: pre_commit_hooks/yamlfmt.py
             language: python
             types: [yaml]
             additional_dependencies:
@@ -29,7 +29,7 @@ repos:
           - id: yamlfmt
             name: Format YAML files with overrides
             description: Format YAML files with overrides
-            entry: pre_commit_hooks/yamlfmt
+            entry: pre_commit_hooks/yamlfmt.py
             language: python
             files: .pre-commit-hooks.yaml
             additional_dependencies:

--- a/ci/test
+++ b/ci/test
@@ -8,26 +8,26 @@ set -o pipefail
 ################################################################################
 . ci/functions.sh
 
-run pre_commit_hooks/yamlfmt --help
+run pre_commit_hooks/yamlfmt.py --help
 echo
 
 run pre-commit try-repo . --files .pre-commit-config.yaml
 
 while read -r file; do
-    run pre_commit_hooks/yamlfmt --mapping 4 --sequence 6 --offset 4 "${file}"
+    run pre_commit_hooks/yamlfmt.py --mapping 4 --sequence 6 --offset 4 "${file}"
 done < <(find . -regex '.*\.yaml')
 
 echo "[INFO] Use with xargs"
 find . -regex '.*\.yaml' -print0 |
-    xargs -0 pre_commit_hooks/yamlfmt -m 4 -s 6 -o 4
+    xargs -0 pre_commit_hooks/yamlfmt.py -m 4 -s 6 -o 4
 echo
 
-run pre_commit_hooks/yamlfmt -m 2 -s 2 -o 0 .pre-commit-hooks.yaml
+run pre_commit_hooks/yamlfmt.py -m 2 -s 2 -o 0 .pre-commit-hooks.yaml
 
 # Ensure we never break multidoc.
 TMP_FILE="$(mktemp pre-commit-hook-yamlfmt-test.XXXXXXXXXXXXXXXXXXXX)"
 run cp -f ci/multidoc-before.txt "${TMP_FILE}"
-run pre_commit_hooks/yamlfmt --mapping 4 --sequence 6 --offset 4 "${TMP_FILE}"
+run pre_commit_hooks/yamlfmt.py --mapping 4 --sequence 6 --offset 4 "${TMP_FILE}"
 run diff ci/multidoc-after.yaml "${TMP_FILE}"
 # If the diff fails, the temp file is still there to inspect.
 run rm -f "${TMP_FILE}"
@@ -35,7 +35,7 @@ run rm -f "${TMP_FILE}"
 # Test preserve quotes
 TMP_FILE="$(mktemp pre-commit-hook-yamlfmt-test.XXXXXXXXXXXXXXXXXXXX)"
 run cp -f ci/quotes-before.txt "${TMP_FILE}"
-run pre_commit_hooks/yamlfmt --mapping 4 --sequence 6 --offset 4 --preserve-quotes "${TMP_FILE}"
+run pre_commit_hooks/yamlfmt.py --mapping 4 --sequence 6 --offset 4 --preserve-quotes "${TMP_FILE}"
 run diff ci/quotes-after.txt "${TMP_FILE}"
 # If the diff fails, the temp file is still there to inspect.
 run rm -f "${TMP_FILE}"
@@ -43,10 +43,10 @@ run rm -f "${TMP_FILE}"
 # Test width setting
 TMP_FILE="$(mktemp pre-commit-hook-yamlfmt-test.XXXXXXXXXXXXXXXXXXXX)"
 run cp -f ci/test-long.txt "${TMP_FILE}"
-run pre_commit_hooks/yamlfmt --width 250 "${TMP_FILE}"
+run pre_commit_hooks/yamlfmt.py --width 250 "${TMP_FILE}"
 # Width=250, no change
 run diff ci/test-long.txt "${TMP_FILE}"
-run pre_commit_hooks/yamlfmt --width 79 "${TMP_FILE}"
+run pre_commit_hooks/yamlfmt.py --width 79 "${TMP_FILE}"
 # Now we should see no lines > 81 (it has some offset in ruamel)
 run grep -v -q '.\{82\}' "${TMP_FILE}"
 run rm -f "${TMP_FILE}"

--- a/pre_commit_hooks/__init__.py
+++ b/pre_commit_hooks/__init__.py
@@ -1,0 +1,1 @@
+"""Init to import yamlfmt."""

--- a/pre_commit_hooks/yamlfmt.py
+++ b/pre_commit_hooks/yamlfmt.py
@@ -14,10 +14,10 @@ DEFAULT_INDENT = {
 
 class Cli:
     # pylint: disable=too-few-public-methods
-    """ command-line-interface """
+    """Command-line-interface."""
 
     def __init__(self):
-        """ initialize the CLI """
+        """Initialize the CLI."""
         parser = argparse.ArgumentParser(
             description="Format YAML files",
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -116,9 +116,12 @@ class Cli:
 class Formatter:
     """
     Reformat a yaml file with proper indentation.
+
     Preserve comments.
     """
+
     def __init__(self, **kwargs):
+        """Initialize the formatter."""
         yaml = YAML()
         yaml.indent(
             mapping=kwargs.get("mapping", DEFAULT_INDENT["mapping"]),
@@ -141,16 +144,16 @@ class Formatter:
         self.content = list({})
 
     def format(self, path=None):
-        """ Read file and write it out to same path """
+        """Read file and write it out to same path."""
         if not path:
             path = self.path
         print(path, end="")
-        FORMATTER.parse_file(path)  # pylint: disable=E0601
-        FORMATTER.write_file(path)
+        self.parse_file(path)  # pylint: disable=E0601
+        self.write_file(path)
         print("  Done")
 
     def parse_file(self, path=None):
-        """ Read the file """
+        """Read the file."""
         if not path:
             path = self.path
         try:
@@ -160,7 +163,7 @@ class Formatter:
             self.fail(f"Unable to read {path}")
 
     def write_file(self, path=None):
-        """ Write the file """
+        """Write the file."""
         if not path:
             path = self.path
         try:
@@ -171,23 +174,28 @@ class Formatter:
 
     @staticmethod
     def fail(msg):
-        """ Abort """
+        """Abort."""
         sys.stderr.write(msg)
         sys.exit(1)
 
 
-if __name__ == "__main__":
-    ARGS = Cli().parser.parse_args()
-    FORMATTER = Formatter(
-        mapping=ARGS.mapping,
-        sequence=ARGS.sequence,
-        offset=ARGS.offset,
-        colons=ARGS.colons,
-        width=ARGS.width,
-        preserve_quotes=ARGS.preserve_quotes,
-        preserve_null=ARGS.preserve_null,
-        explicit_start=ARGS.explicit_start,
-        explicit_end=ARGS.explicit_end
+def main():
+    """Run formatter."""
+    args = Cli().parser.parse_args()
+    formatter = Formatter(
+        mapping=args.mapping,
+        sequence=args.sequence,
+        offset=args.offset,
+        colons=args.colons,
+        width=args.width,
+        preserve_quotes=args.preserve_quotes,
+        preserve_null=args.preserve_null,
+        explicit_start=args.explicit_start,
+        explicit_end=args.explicit_end
         )
-    for file_name in ARGS.file_names:
-        FORMATTER.format(file_name)
+    for file_name in args.file_names:
+        formatter.format(file_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,24 @@
 """Fake setup for pre-commit hook."""
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='yamlfmt',
     description='A pre-commit hook to format YAML files',
     url='https://github.com/jumanjihouse/pre-commit-hook-yamlfmt',
-    version='0.0.0',
+    version='0.0.1',
 
     install_requires=[
         'ruamel.yaml >=0.16.10, <=0.17.21',
     ],
 
-    scripts=[
-        'pre_commit_hooks/yamlfmt',
-    ],
+    entry_points={
+        'console_scripts': [
+            'yamlfmt = pre_commit_hooks.yamlfmt:main',
+        ],
+    },
 
     # explicitly declare packages so setuptools does not attempt auto discovery
     # taken from https://github.com/pypa/setuptools/issues/3197
-    packages=[],
+    packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name='yamlfmt',
     description='A pre-commit hook to format YAML files',
     url='https://github.com/jumanjihouse/pre-commit-hook-yamlfmt',
-    version='0.0.1',
+    version='0.3.0',
 
     install_requires=[
         'ruamel.yaml >=0.16.10, <=0.17.21',


### PR DESCRIPTION
This fixes issues #25 and #32.

On windows, the tool is broken due to the use of `scripts` in `setup.py`.  The shebang that is generated to run the script doesn't correctly escape path characters.

Recommendation is to change to use of `entry_points` and `console_scripts` instead of `scripts` in `setup.py`.  The `scripts` method is old and brittle.  Since this is just calling python code (rather than bash, ruby, etc), the use of `scripts` isn't the cleanest method.


Quick high-level summary of the differences in how these two methods work: https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html

More in-depth: https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#scripts
https://packaging.python.org/en/latest/specifications/entry-points/


This PR is basically an update of #42 which is out of date.  This one also keeps the shebang in the script so it can still be run traditionally as well.

No modification of downstream `.pre-commit-config.yaml` configuration should be needed, so this should be a seamless change to consumers of this tool.

It would be really nice to get this merged to fix the cross-platform issues that have been lingering for a few years. @jumanjiman 😃 